### PR TITLE
Add ImmutableLoadingBar for immutable top level store

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ export function* fetchData() {
 }
 ```
 
+## Usage with `immutable-js`
+
+You can change component import line if your top level redux store object is `immutable`.
+
+```jsx
+import { ImmutableLoadingBar as LoadingBar } from 'react-redux-loading-bar'
+
+// Use LoadingBar component as usual
+```
+
 ## Usage with jQuery Ajax Requests
 
 If you happen to use jQuery for Ajax requests, you can dispatch `SHOW`/`HIDE` actions on `ajaxStart`/`ajaxStop` global events:

--- a/build/immutable.js
+++ b/build/immutable.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _reactRedux = require('react-redux');
+
+var _loading_bar = require('./loading_bar');
+
+var mapImmutableStateToProps = function mapImmutableStateToProps(state) {
+  return {
+    loading: state.get('loadingBar')
+  };
+};
+
+exports.default = (0, _reactRedux.connect)(mapImmutableStateToProps)(_loading_bar.LoadingBar);

--- a/build/index.js
+++ b/build/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.LoadingBar = exports.hideLoading = exports.showLoading = exports.loadingBarReducer = exports.loadingBarMiddleware = undefined;
+exports.ImmutableLoadingBar = exports.LoadingBar = exports.hideLoading = exports.showLoading = exports.loadingBarReducer = exports.loadingBarMiddleware = undefined;
 
 var _loading_bar = require('./loading_bar');
 
@@ -15,6 +15,10 @@ var _loading_bar_middleware2 = _interopRequireDefault(_loading_bar_middleware);
 
 var _loading_bar_ducks = require('./loading_bar_ducks');
 
+var _immutable = require('./immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.loadingBarMiddleware = _loading_bar_middleware2.default;
@@ -22,4 +26,5 @@ exports.loadingBarReducer = _loading_bar_ducks.loadingBarReducer;
 exports.showLoading = _loading_bar_ducks.showLoading;
 exports.hideLoading = _loading_bar_ducks.hideLoading;
 exports.LoadingBar = _loading_bar.LoadingBar;
+exports.ImmutableLoadingBar = _immutable2.default;
 exports.default = _loading_bar2.default;

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,0 +1,8 @@
+import { connect } from 'react-redux'
+import { LoadingBar } from './loading_bar'
+
+const mapImmutableStateToProps = (state) => ({
+  loading: state.get('loadingBar'),
+})
+
+export default connect(mapImmutableStateToProps)(LoadingBar)

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   showLoading,
   hideLoading,
 } from './loading_bar_ducks'
+import ImmutableLoadingBar from './immutable'
 
 export {
   loadingBarMiddleware,
@@ -12,5 +13,6 @@ export {
   showLoading,
   hideLoading,
   LoadingBar,
+  ImmutableLoadingBar,
 }
 export default LoadingBarContainer


### PR DESCRIPTION
When top level redux store is immutable `state.loadingBar` don't work and we need to use `state.get('loadingBar')`.

This PR adds `ImmutableLoadingBar` component with simple usage:

```jsx
import { ImmutableLoadingBar as LoadingBar } from 'react-redux-loading-bar'
```