### PR TITLE
Fix memory leaks caused by multiple start calls

### DIFF
--- a/src/loading_bar.js
+++ b/src/loading_bar.js
@@ -89,6 +89,9 @@ class LoadingBar extends Component {
   }
 
   start() {
+    if (this.progressIntervalId) {
+      clearInterval(this.progressIntervalId);
+    }
     this.progressIntervalId = setInterval(
       this.simulateProgress,
       this.props.updateTime,

--- a/src/loading_bar.js
+++ b/src/loading_bar.js
@@ -90,7 +90,7 @@ class LoadingBar extends Component {
 
   start() {
     if (this.progressIntervalId) {
-      clearInterval(this.progressIntervalId);
+      clearInterval(this.progressIntervalId)
     }
     this.progressIntervalId = setInterval(
       this.simulateProgress,


### PR DESCRIPTION
if start called multiple times should clear previous interval to avoid memory leak