### PR TITLE
Re-export constants from reducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,28 @@
 import LoadingBarContainer, { LoadingBar } from './loading_bar'
 import loadingBarMiddleware from './loading_bar_middleware'
 import {
+  DEFAULT_SCOPE,
+  HIDE,
   hideLoading,
   loadingBarReducer,
+  RESET,
   resetLoading,
+  SHOW,
   showLoading,
 } from './loading_bar_ducks'
 import ImmutableLoadingBar from './immutable'
 
 export {
+  DEFAULT_SCOPE,
+  HIDE,
   hideLoading,
   ImmutableLoadingBar,
   LoadingBar,
   loadingBarMiddleware,
   loadingBarReducer,
+  RESET,
   resetLoading,
+  SHOW,
   showLoading,
 }
 export default LoadingBarContainer


### PR DESCRIPTION
PR makes it so that the constants (`DEFAULT_SCOPE`, `HIDE`, `RESET`, `SHOW`) from the reducer file so that downstream libraries can use them.

In our application, we want to implement our own version of `loadingBarReducer` where the state is a simple toggle, vs it being a counter, and having these be a top level exports would simplify things / give us confidence that our implementation won't break on us.