### PR TITLE
Update types definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,20 @@
 import { Component, CSSProperties } from 'react';
 import { Middleware, Reducer, Action } from 'redux';
 
+export const DEFAULT_SCOPE: string;
+export const HIDE: string;
+export const SHOW: string;
+export const RESET: string;
+
 export interface LoadingBarContainerProps {
-  scope?: string
-  style?: CSSProperties;
   className?: string;
-  actions?: Object;
-  updateTime?: number;
+  direction?: string;
   maxProgress?: number;
   progressIncrease?: number;
+  scope?: string;
   showFastActions?: boolean;
+  style?: CSSProperties;
+  updateTime?: number;
 }
 export default class LoadingBarContainer extends Component<LoadingBarContainerProps, {}> {}
 


### PR DESCRIPTION
Updates the type definition for stuff added in:
* d4063b36e062917f84a69beaac7809d98cf9b231 (export scope constants)
* ed27ad22cdb2f0e25787e88cc4c5f1ea9cc0fa1f (support for RTL)

Sorry for not including the scope constants in #132, for some reason I thought we were using a `@types` package, and not that this package had its own types file.